### PR TITLE
Improve page styling and usability

### DIFF
--- a/bestellung/cart.php
+++ b/bestellung/cart.php
@@ -11,11 +11,11 @@ ob_start();
 <?php $sum = 0; foreach ($cart as $item): $sum += $item['product']['price']*$item['qty']; ?>
   <div class="cart-item">
     <?= htmlspecialchars($item['product']['name']) ?> x <?= $item['qty'] ?> - €<?= number_format($item['product']['price']*$item['qty'],2) ?>
-    <a href="remove_from_cart.php?id=<?= $item['product']['id'] ?>">Entfernen</a>
+    <a class="button" href="remove_from_cart.php?id=<?= $item['product']['id'] ?>">Entfernen</a>
   </div>
 <?php endforeach; ?>
 <p><strong>Gesamt: €<?= number_format($sum,2) ?></strong></p>
-<a href="checkout.php">Zur Kasse</a>
+<a class="button" href="checkout.php">Zur Kasse</a>
 <?php endif; ?>
 <?php
 $content = ob_get_clean();

--- a/bestellung/checkout.php
+++ b/bestellung/checkout.php
@@ -69,6 +69,7 @@ ob_start();
       <input type="text" name="card_number" pattern="\d{16}">
     </label>
   </div>
+  <p><a class="button" href="cart.php">Zur\xC3\xBCck zum Warenkorb</a></p>
   <button type="submit">Bestellung abschicken</button>
 </form>
 <?php

--- a/bestellung/order-confirmation.php
+++ b/bestellung/order-confirmation.php
@@ -22,7 +22,7 @@ ob_start();
 <?php else: ?>
 <p>Bestellung nicht gefunden.</p>
 <?php endif; ?>
-<a href="/index.php">Weiter einkaufen</a>
+<a class="button" href="/index.php">Weiter einkaufen</a>
 <?php
 $content = ob_get_clean();
 include __DIR__.'/../app.php';

--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,12 @@
 body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f8f8f8; }
 header, footer { background: #2c3e50; color: #fff; padding: 10px 0; }
 header a, footer a { color: #fff; text-decoration: none; margin-right: 15px; }
+a { color: #2c3e50; text-decoration: none; }
+a:hover { color: #e67e22; }
 .container { width: 90%; max-width: 900px; margin: 20px auto; }
 .product { background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 15px; margin-bottom: 15px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .cart-item { border-bottom: 1px solid #eee; padding: 8px 0; display: flex; justify-content: space-between; }
-button { padding: 8px 15px; cursor: pointer; background: #3498db; color: #fff; border: none; border-radius: 4px; }
+button, .button { padding: 8px 15px; cursor: pointer; background: #e67e22; color: #fff; border: none; border-radius: 4px; display: inline-block; }
 form label { display: block; margin-top: 10px; }
 input, textarea, select { padding: 8px; width: 100%; box-sizing: border-box; margin-top: 5px; }
-button:hover { background: #2980b9; }
+button:hover, .button:hover { background: #d35400; }


### PR DESCRIPTION
## Summary
- restyle buttons with a warm orange tone
- style links globally to avoid blue default color
- make cart actions and navigation buttons more visible
- add a back-to-cart link on the checkout page

## Testing
- `php` linting *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68420abc14b883309bdff0484cdeceb4